### PR TITLE
[IMP] l10n_es_aeat_mod340: Store record number

### DIFF
--- a/l10n_es_aeat_mod340/models/mod340.py
+++ b/l10n_es_aeat_mod340/models/mod340.py
@@ -190,6 +190,7 @@ class L10nEsAeatMod340Issued(orm.Model):
         'date_payment': fields.date('Date Payment', readonly=True),
         'payment_amount': fields.float('Payment amount', digits=(13, 2)),
         'name_payment_method': fields.char('Method Payment', size=34),
+        'record_number': fields.char(string='Record number', readonly=True)
     }
 
     _order = 'date_invoice asc, invoice_id asc'

--- a/l10n_es_aeat_mod340/report/mod340_report.rml
+++ b/l10n_es_aeat_mod340/report/mod340_report.rml
@@ -163,10 +163,10 @@
     <blockTable colWidths="237.0,244.0" style="Taula1">
       <tr>
         <td>
-          <para style="P3">CIF/NIF: </para>
+          <para style="P3">NIF: </para>
           <para style="P3">Teléfono de contacto: </para>
           <para style="P3">Apellidos y nombre de contacto: </para>
-          <para style="P3">CIF/NIF del representante legal: </para>
+          <para style="P3">NIF del representante legal: </para>
           <para style="P3">Tipo de declaración </para>
           <para style="P3">Número de la declaración anterior: </para>
           <para style="P3">Código electrónico autoliquidación IVA: </para>

--- a/l10n_es_aeat_mod340/report/vat_book.rml
+++ b/l10n_es_aeat_mod340/report/vat_book.rml
@@ -192,9 +192,7 @@
         <td>
           <para style="P2">[[o.company_id.name or '']] </para>
           <para style="P2">[[o.fiscalyear_id.name or '']] </para>
-            <para style="P2">[[repeatIn(o.periods,'p')]]
-           [[p.name]] -
-           </para>
+          <para style="P2">[[', '.join(o.mapped('periods.name'))]] </para>
         </td>
       </tr>
     </blockTable>
@@ -207,7 +205,7 @@
     <blockTable colWidths="237.0,244.0" style="Taula1">
       <tr>
         <td>
-          <para style="P3">CIF/NIF: </para>
+          <para style="P3">NIF: </para>
           <para style="P3">Teléfono de contacto: </para>
           <para style="P3">Apellidos y nombre de contacto: </para>
         </td>
@@ -226,10 +224,13 @@
       <font color="white"> </font>
     </para>
 
-    <blockTable colWidths="53.0,63.0,140.0,62.0,164.0" repeatRows="1" style="Taula3">
+    <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,134.0" repeatRows="1" style="Taula3">
       <tr>
         <td>
           <para style="Table Heading">Fecha factura</para>
+        </td>
+        <td>
+          <para style="Table Heading">Nº registro</para>
         </td>
         <td>
           <para style="Table Heading">Número de factura</para>
@@ -238,10 +239,10 @@
           <para style="Table Heading">Empresa</para>
         </td>
         <td>
-          <para style="Table Heading">CIF/NIF</para>
+          <para style="Table Heading">NIF</para>
         </td>
         <td>
-            <blockTable colWidths="61.0,49.0,54.0" repeatRows="1" style="TablaInterna">
+            <blockTable colWidths="56.0,29.0,49.0" repeatRows="1" style="TablaInterna">
                 <tr>
                     <td>
                       <para style="Table Heading">Base</para>
@@ -263,10 +264,13 @@
     </para>
     <section>
       <para style="P6">[[repeatIn(o.issued,'r')]]</para>
-      <blockTable colWidths="53.0,63.0,140.0,62.0,164.0" repeatRows="1" style="Taula4">
+      <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,134.0" repeatRows="1" style="Taula4">
         <tr>
           <td>
             <para style="P11">[[ formatLang(r.invoice_id.date_invoice,date=True) ]]</para>
+          </td>
+           <td>
+            <para style="P11">[[r.record_number]]</para>
           </td>
            <td>
             <para style="P11">[[r.invoice_id.number]]</para>
@@ -279,7 +283,7 @@
           </td>
           <td>
             <para style="P6">[[repeatIn(r.tax_line_ids,'l')]]</para>
-                <blockTable colWidths="61.0,49.0,54.0" repeatRows="1" style="TablaInterna">
+                <blockTable colWidths="56.0,29.0,49.0" repeatRows="1" style="TablaInterna">
                 <tr>
                     <td>
                         <para style="P10">[[formatLang(l.base_amount)]]</para>
@@ -401,16 +405,16 @@
           <para style="Table Heading">Fecha</para>
         </td>
         <td>
-          <para style="Table Heading">Nº de factura</para>
+          <para style="Table Heading">Nº registro</para>
         </td>
         <td>
-          <para style="Table Heading">Nº registro</para>
+          <para style="Table Heading">Nº de factura</para>
         </td>
         <td>
           <para style="Table Heading">Empresa</para>
         </td>
         <td>
-          <para style="Table Heading">CIF/NIF</para>
+          <para style="Table Heading">NIF</para>
         </td>
         <td>
             <blockTable colWidths="51.0,49.0,54.0" repeatRows="1" style="TablaInterna">
@@ -440,10 +444,10 @@
             <para style="P11">[[ formatLang(r.invoice_id.date_invoice,date=True) ]]</para>
           </td>
           <td>
-            <para style="P11">[[r.invoice_id.reference or '']]</para>
+            <para style="P11">[[r.record_number ]]</para>
           </td>
           <td>
-            <para style="P11">[[r.invoice_id.number ]]</para>
+            <para style="P11">[[r.invoice_id.reference or r.invoice_id.number or '']]</para>
           </td>
           <td>
             <para style="P9">[[r.partner_id.name]]</para>

--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -57,6 +57,7 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
         invoices340_rec = self.pool['l10n.es.aeat.mod340.received']
         issued_obj = self.pool['l10n.es.aeat.mod340.tax_line_issued']
         received_obj = self.pool['l10n.es.aeat.mod340.tax_line_received']
+        sequence_obj = self.pool['ir.sequence']
         mod340.write({
             'state': 'calculated',
             'calculation_date': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
@@ -134,6 +135,7 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
                     'amount_tax': invoice.cc_amount_tax * sign,
                     'total': invoice.cc_amount_total * sign,
                     'date_invoice': invoice.date_invoice,
+                    'record_number': sequence_obj.get(cr, uid, 'mod340'),
                 }
                 date_payment = False
                 payment_amount = 0
@@ -254,7 +256,7 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
                                     ('invoice_record_id', '=', invoice_created),
                                     ('tax_code_id', '=', tax_line.base_code_id.id),
                                     ('tax_percentage','=', tax_percentage),
-                                ]                                
+                                ]
                                 if sign == 1:
                                     domain.append(('tax_amount', '>=', 0))
                                 else:

--- a/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py
+++ b/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py
@@ -79,7 +79,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
             text = text.upper().encode('iso-8859-1', 'ignore')
         else:
             text = str(text or '').upper()
-        
+
         for i in text:
             if xlate.has_key(ord(i)):
                 ascii_string += xlate[ord(i)]
@@ -247,7 +247,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
             text += 3 * ' '
             # Clave tipo de libro. Constante 'E'.
             text += 'E'
-            # Clave de operación              
+            # Clave de operación
             text +=  self._formatString(invoice_issued.key_operation, 1)
             text += self._formatNumber(
                 invoice_issued.invoice_id.date_invoice.split('-')[0], 4)
@@ -277,8 +277,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
             # Identificación de la factura
             text += self._formatString(invoice_issued.invoice_id.number, 40)
             # Número de registro
-            sequence_obj = self.env['ir.sequence']
-            text += self._formatString(sequence_obj.get('mod340'), 18)
+            text += self._formatString(invoice_issued.record_number, 18)
             # Número de facturas
             if invoice_issued.invoice_id.is_ticket_summary == 1:
                 text += self._formatNumber(
@@ -446,8 +445,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
             text += self._formatString(invoice_received.supplier_invoice_number,
                                        40)
             # Número de registro
-            sequence_obj = self.env['ir.sequence']
-            text += self._formatString(sequence_obj.get('mod340'), 18)
+            text += self._formatString(invoice_received.record_number, 18)
             # Número de facturas
             text += self._formatNumber(1, 18)
             # Número de registros (Desglose)
@@ -479,7 +477,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
                 text += 13 * '0'
                 text += ' '
                 text += 34 * ' '
-            
+
             # Blancos
             text += 95 * ' '
             text += '\r\n'


### PR DESCRIPTION
@kikopeiro, con esto se soluciona lo que te dije de la numeración de las facturas. El problema es que se hace en la exportación, pero no cuando imprimes el listado de IVA, que también debe estar. Además, si le das dos veces a exportar, se regenera los números dos veces. De esta formas, ya sólo se calcula una vez, no cada vez que exportes.
