### PR TITLE
[IMP] l10n_es_igic: Backport de los cambios de la 12.0

### DIFF
--- a/l10n_es_igic/__manifest__.py
+++ b/l10n_es_igic/__manifest__.py
@@ -24,7 +24,6 @@
     "depends": ['l10n_es'],
     "license": "AGPL-3",
     'data': [
-        'data/account_chart_template_igic.xml',
         'data/account_account_common_igic.xml',
         'data/account_tax_group_data.xml',
         'data/taxes_common_igic.xml',

--- a/l10n_es_igic/data/account_tax_group_data.xml
+++ b/l10n_es_igic/data/account_tax_group_data.xml
@@ -9,6 +9,9 @@
     <record id="tax_group_igic_6_5" model="account.tax.group">
         <field name="name">IGIC 6,5%</field>
     </record>
+    <record id="tax_group_igic_7" model="account.tax.group">
+        <field name="name">IGIC 7%</field>
+    </record>
     <record id="tax_group_igic_95" model="account.tax.group">
         <field name="name">IGIC 9,5%</field>
     </record>

--- a/l10n_es_igic/data/fiscal_position_common_igic.xml
+++ b/l10n_es_igic/data/fiscal_position_common_igic.xml
@@ -2,10 +2,8 @@
 <odoo>
 
     <record id="fp_extra_canarias" model="account.fiscal.position.template">
-        <field name="name">
-            Régimen de Importaciones/Exportaciones a/desde Canarias
-        </field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="name">Régimen de Importaciones/Exportaciones a/desde Canarias</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     </record>
 
     <!--Soportado Operaciones corrientes -->
@@ -23,6 +21,11 @@
         <field name="position_id" ref="fp_extra_canarias"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_6_5"/>
+    </record>
+    <record id="igic_fptt_extra_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_extra_canarias"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_7"/>
     </record>
     <record id="igic_fptt_extra_9_5" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_extra_canarias"/>
@@ -55,6 +58,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_6_5_inv"/>
     </record>
+    <record id="igic_fptt_extra_7_inv" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_extra_canarias"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_7_inv"/>
+    </record>
     <record id="igic_fptt_extra_9_5_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_extra_canarias"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -86,6 +94,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_ex_0"/>
     </record>
+    <record id="igic_fptt_extra_ventas_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_extra_canarias"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_ex_0"/>
+    </record>
     <record id="igic_fptt_extra_ventas_9_5" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_extra_canarias"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_9_5"/>
@@ -107,10 +120,8 @@
     <!--Soportado Operaciones corrientes -->
 
     <record id="fp_re_import_igic" model="account.fiscal.position.template">
-        <field name="name">
-            Régimen de Recargo a la importación (IGIC)
-        </field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="name">Régimen de Recargo a la importación (IGIC)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     </record>
 
     <record id="igic_fptt_recargo_buy_3_A" model="account.fiscal.position.tax.template">
@@ -131,6 +142,16 @@
     <record id="igic_fptt_recargo_buy_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_re_import_igic"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_p_re05"/>
+    </record>
+    <record id="igic_fptt_recargo_buy_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_recargo_buy_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_re05"/>
     </record>
     <record id="igic_fptt_recargo_buy_9_5_A" model="account.fiscal.position.tax.template">
@@ -184,6 +205,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_re05"/>
     </record>
+    <record id="igic_fptt_recargo_buy_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_recargo_buy_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_p_re05"/>
+    </record>
     <record id="igic_fptt_recargo_buy_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_re_import_igic"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -214,7 +245,7 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_re20"/>
     </record>
-        <!-- Repercutido -->
+    <!-- Repercutido -->
     <record id="igic_fptt_recargo_3_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_re_import_igic"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_3"/>
@@ -233,6 +264,16 @@
     <record id="igic_fptt_recargo_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_re_import_igic"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_re_05"/>
+    </record>
+    <record id="igic_fptt_recargo_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_recargo_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_re_import_igic"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_re_05"/>
     </record>
     <record id="igic_fptt_recargo_9_5_A" model="account.fiscal.position.tax.template">
@@ -266,10 +307,10 @@
         <field name="tax_dest_id" ref="account_tax_template_igic_re_20"/>
     </record>
     <!-- =================== -->
-        <!-- Retenciones IRPF 1% -->
-        <!-- =================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf1_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 1% -->
+    <!-- =================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf1_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf1"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -297,6 +338,16 @@
     <record id="igic_fptt_irpf1_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf1"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf1"/>
+    </record>
+    <record id="igic_fptt_irpf1_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf1_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf1"/>
     </record>
     <record id="igic_fptt_irpf1_9_5_A" model="account.fiscal.position.tax.template">
@@ -360,6 +411,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf1"/>
     </record>
+    <record id="igic_fptt_irpf1_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf1_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf1"/>
+    </record>
     <record id="igic_fptt_irpf1_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf1"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -390,8 +451,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf1"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf1sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf1sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf1"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -419,6 +480,16 @@
     <record id="igic_fptt_irpf1sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf1"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf1"/>
+    </record>
+    <record id="igic_fptt_irpf1sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf1sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf1"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf1"/>
     </record>
     <record id="igic_fptt_irpf1sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -452,10 +523,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf1"/>
     </record>
     <!-- =================== -->
-        <!-- Retenciones IRPF 2% -->
-        <!-- =================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf2_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 2% -->
+    <!-- =================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf2_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf2"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -483,6 +554,16 @@
     <record id="igic_fptt_irpf2_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf2"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
+    </record>
+    <record id="igic_fptt_irpf2_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf2_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
     </record>
     <record id="igic_fptt_irpf2_9_5_A" model="account.fiscal.position.tax.template">
@@ -546,6 +627,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
     </record>
+    <record id="igic_fptt_irpf2_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf2_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
+    </record>
     <record id="igic_fptt_irpf2_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf2"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -576,8 +667,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf2sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf2sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf2"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -605,6 +696,16 @@
     <record id="igic_fptt_irpf2sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf2"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf2"/>
+    </record>
+    <record id="igic_fptt_irpf2sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf2sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf2"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf2"/>
     </record>
     <record id="igic_fptt_irpf2sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -638,10 +739,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf2"/>
     </record>
     <!-- =================== -->
-        <!-- Retenciones IRPF 7% -->
-        <!-- =================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf7_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 7% -->
+    <!-- =================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf7_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf7"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -669,6 +770,16 @@
     <record id="igic_fptt_irpf7_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf7"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf7"/>
+    </record>
+    <record id="igic_fptt_irpf7_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf7_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf7"/>
     </record>
     <record id="igic_fptt_irpf7_9_5_A" model="account.fiscal.position.tax.template">
@@ -732,6 +843,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf7"/>
     </record>
+    <record id="igic_fptt_irpf7_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf7_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf7"/>
+    </record>
     <record id="igic_fptt_irpf7_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf7"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -762,8 +883,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf7"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf7sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf7sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf7"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -791,6 +912,16 @@
     <record id="igic_fptt_irpf7sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf7"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf7"/>
+    </record>
+    <record id="igic_fptt_irpf7sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf7sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf7"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf7"/>
     </record>
     <record id="igic_fptt_irpf7sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -824,10 +955,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf7"/>
     </record>
     <!-- =================== -->
-        <!-- Retenciones IRPF 9% -->
-        <!-- =================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf9_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 9% -->
+    <!-- =================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf9_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf9"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -855,6 +986,16 @@
     <record id="igic_fptt_irpf9_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf9"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9"/>
+    </record>
+    <record id="igic_fptt_irpf9_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf9_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9"/>
     </record>
     <record id="igic_fptt_irpf9_9_5_A" model="account.fiscal.position.tax.template">
@@ -918,6 +1059,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9"/>
     </record>
+    <record id="igic_fptt_irpf9_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf9_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9"/>
+    </record>
     <record id="igic_fptt_irpf9_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf9"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -948,8 +1099,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf9sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf9sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf9"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -977,6 +1128,16 @@
     <record id="igic_fptt_irpf9sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf9"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf9"/>
+    </record>
+    <record id="igic_fptt_irpf9sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf9sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf9"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf9"/>
     </record>
     <record id="igic_fptt_irpf9sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1010,10 +1171,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf9"/>
     </record>
     <!-- ==================== -->
-        <!-- Retenciones IRPF 15% -->
-        <!-- ==================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf15_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 15% -->
+    <!-- ==================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf15_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf15"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -1041,6 +1202,16 @@
     <record id="igic_fptt_irpf15_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf15"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15"/>
+    </record>
+    <record id="igic_fptt_irpf15_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf15_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15"/>
     </record>
     <record id="igic_fptt_irpf15_9_5_A" model="account.fiscal.position.tax.template">
@@ -1104,6 +1275,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15"/>
     </record>
+    <record id="igic_fptt_irpf15_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf15_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15"/>
+    </record>
     <record id="igic_fptt_irpf15_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf15"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -1134,8 +1315,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf15sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf15sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf15"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -1163,6 +1344,16 @@
     <record id="igic_fptt_irpf15sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf15"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf15"/>
+    </record>
+    <record id="igic_fptt_irpf15sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf15sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf15"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf15"/>
     </record>
     <record id="igic_fptt_irpf15sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1196,10 +1387,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf15"/>
     </record>
     <!-- ==================== -->
-        <!-- Retenciones IRPF 18% -->
-        <!-- ==================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf18_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 18% -->
+    <!-- ==================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf18_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf18"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -1227,6 +1418,16 @@
     <record id="igic_fptt_irpf18_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf18"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf18"/>
+    </record>
+    <record id="igic_fptt_irpf18_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf18_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf18"/>
     </record>
     <record id="igic_fptt_irpf18_9_5_A" model="account.fiscal.position.tax.template">
@@ -1290,6 +1491,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf18"/>
     </record>
+    <record id="igic_fptt_irpf18_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf18_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf18"/>
+    </record>
     <record id="igic_fptt_irpf18_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf18"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -1320,8 +1531,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf18"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf18sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf18sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf18"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -1349,6 +1560,16 @@
     <record id="igic_fptt_irpf18sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf18"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf18"/>
+    </record>
+    <record id="igic_fptt_irpf18sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf18sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf18"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf18"/>
     </record>
     <record id="igic_fptt_irpf18sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1416,6 +1637,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19"/>
     </record>
+    <record id="igic_fptt_irpf19_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf19_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19"/>
+    </record>
     <record id="igic_fptt_irpf19_9_5_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5"/>
@@ -1477,6 +1708,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19"/>
     </record>
+    <record id="igic_fptt_irpf19_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf19_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19"/>
+    </record>
     <record id="igic_fptt_irpf19_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -1507,8 +1748,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf19sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf19sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -1536,6 +1777,16 @@
     <record id="igic_fptt_irpf19sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19"/>
+    </record>
+    <record id="igic_fptt_irpf19sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf19sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19"/>
     </record>
     <record id="igic_fptt_irpf19sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1569,10 +1820,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19"/>
     </record>
     <!-- ==================== -->
-        <!-- Retenciones IRPF 20% -->
-        <!-- ==================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf20_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 20% -->
+    <!-- ==================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf20_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -1600,6 +1851,16 @@
     <record id="igic_fptt_irpf20_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20"/>
+    </record>
+    <record id="igic_fptt_irpf20_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf20_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20"/>
     </record>
     <record id="igic_fptt_irpf20_9_5_A" model="account.fiscal.position.tax.template">
@@ -1663,6 +1924,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20"/>
     </record>
+    <record id="igic_fptt_irpf20_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf20_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20"/>
+    </record>
     <record id="igic_fptt_irpf20_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -1693,8 +1964,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf20sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf20sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -1722,6 +1993,16 @@
     <record id="igic_fptt_irpf20sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20"/>
+    </record>
+    <record id="igic_fptt_irpf20sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf20sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20"/>
     </record>
     <record id="igic_fptt_irpf20sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1755,10 +2036,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20"/>
     </record>
     <!-- ==================== -->
-        <!-- Retenciones IRPF 21% -->
-        <!-- ==================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf21_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 21% -->
+    <!-- ==================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf21_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -1786,6 +2067,16 @@
     <record id="igic_fptt_irpf21_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21p"/>
+    </record>
+    <record id="igic_fptt_irpf21_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf21_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21p"/>
     </record>
     <record id="igic_fptt_irpf21_9_5_A" model="account.fiscal.position.tax.template">
@@ -1849,6 +2140,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21p"/>
     </record>
+    <record id="igic_fptt_irpf21_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf21_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21p"/>
+    </record>
     <record id="igic_fptt_irpf21_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -1879,8 +2180,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21p"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf21sale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf21sale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -1908,6 +2209,16 @@
     <record id="igic_fptt_irpf21sale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21"/>
+    </record>
+    <record id="igic_fptt_irpf21sale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf21sale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21"/>
     </record>
     <record id="igic_fptt_irpf21sale_9_5_A" model="account.fiscal.position.tax.template">
@@ -1941,10 +2252,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21"/>
     </record>
     <!-- =================================== -->
-        <!-- Retenciones IRPF 19% arrendamientos -->
-        <!-- =================================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf19a_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 19% arrendamientos -->
+    <!-- =================================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf19a_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -1972,6 +2283,16 @@
     <record id="igic_fptt_irpf19a_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19a"/>
+    </record>
+    <record id="igic_fptt_irpf19a_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf19a_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19a"/>
     </record>
     <record id="igic_fptt_irpf19a_9_5_A" model="account.fiscal.position.tax.template">
@@ -2065,8 +2386,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19a"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf19asale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf19asale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -2094,6 +2415,16 @@
     <record id="igic_fptt_irpf19asale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf19a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19a"/>
+    </record>
+    <record id="igic_fptt_irpf19asale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf19asale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf19a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19a"/>
     </record>
     <record id="igic_fptt_irpf19asale_9_5_A" model="account.fiscal.position.tax.template">
@@ -2127,10 +2458,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19a"/>
     </record>
     <!-- ===================================== -->
-        <!-- Retenciones IRPF 19,5% arrendamientos -->
-        <!-- ===================================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf195a_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 19,5% arrendamientos -->
+    <!-- ===================================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf195a_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf195a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -2158,6 +2489,16 @@
     <record id="igic_fptt_irpf195a_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf195a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf195a"/>
+    </record>
+    <record id="igic_fptt_irpf195a_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf195a_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf195a"/>
     </record>
     <record id="igic_fptt_irpf195a_9_5_A" model="account.fiscal.position.tax.template">
@@ -2221,6 +2562,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf195a"/>
     </record>
+    <record id="igic_fptt_irpf195a_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf195a_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf195a"/>
+    </record>
     <record id="igic_fptt_irpf195a_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf195a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -2251,8 +2602,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf195a"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf195asale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf195asale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf195a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -2280,6 +2631,16 @@
     <record id="igic_fptt_irpf195asale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf195a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf195a"/>
+    </record>
+    <record id="igic_fptt_irpf195asale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf195asale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf195a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf195a"/>
     </record>
     <record id="igic_fptt_irpf195asale_9_5_A" model="account.fiscal.position.tax.template">
@@ -2313,10 +2674,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf195a"/>
     </record>
     <!-- =================================== -->
-        <!-- Retenciones IRPF 20% arrendamientos -->
-        <!-- =================================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf20a_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 20% arrendamientos -->
+    <!-- =================================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf20a_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -2344,6 +2705,16 @@
     <record id="igic_fptt_irpf20a_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20a"/>
+    </record>
+    <record id="igic_fptt_irpf20a_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf20a_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20a"/>
     </record>
     <record id="igic_fptt_irpf20a_9_5_A" model="account.fiscal.position.tax.template">
@@ -2407,6 +2778,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20a"/>
     </record>
+    <record id="igic_fptt_irpf20a_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf20a_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20a"/>
+    </record>
     <record id="igic_fptt_irpf20a_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -2437,8 +2818,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf20a"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf20asale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf20asale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -2466,6 +2847,16 @@
     <record id="igic_fptt_irpf20asale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf20a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20a"/>
+    </record>
+    <record id="igic_fptt_irpf20asale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf20asale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf20a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20a"/>
     </record>
     <record id="igic_fptt_irpf20asale_9_5_A" model="account.fiscal.position.tax.template">
@@ -2499,10 +2890,10 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf20a"/>
     </record>
     <!-- =================================== -->
-        <!-- Retenciones IRPF 21% arrendamientos -->
-        <!-- =================================== -->
-        <!--Soportado Operaciones corrientes -->
-        <record id="igic_fptt_irpf21a_0_A" model="account.fiscal.position.tax.template">
+    <!-- Retenciones IRPF 21% arrendamientos -->
+    <!-- =================================== -->
+    <!--Soportado Operaciones corrientes -->
+    <record id="igic_fptt_irpf21a_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_0"/>
@@ -2530,6 +2921,16 @@
     <record id="igic_fptt_irpf21a_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21a"/>
+    </record>
+    <record id="igic_fptt_irpf21a_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7"/>
+    </record>
+    <record id="igic_fptt_irpf21a_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21a"/>
     </record>
     <record id="igic_fptt_irpf21a_9_5_A" model="account.fiscal.position.tax.template">
@@ -2588,6 +2989,21 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_6_5_inv"/>
     </record>
+    <record id="igic_fptt_irpf21a_6_5_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21a"/>
+    </record>
+    <record id="igic_fptt_irpf21a_7_inv_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_7_inv"/>
+    </record>
+    <record id="igic_fptt_irpf21a_7_inv_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21a"/>
+    </record>
     <record id="igic_fptt_irpf21a_9_5_inv_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -2618,8 +3034,8 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_200_inv"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf21a"/>
     </record>
-        <!-- Repercutido -->
-        <record id="igic_fptt_irpf21asale_0_A" model="account.fiscal.position.tax.template">
+    <!-- Repercutido -->
+    <record id="igic_fptt_irpf21asale_0_A" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_r_0"/>
@@ -2647,6 +3063,16 @@
     <record id="igic_fptt_irpf21asale_6_5_B" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="l10n_es.fp_irpf21a"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21a"/>
+    </record>
+    <record id="igic_fptt_irpf21asale_7_A" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_7"/>
+    </record>
+    <record id="igic_fptt_irpf21asale_7_B" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_irpf21a"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21a"/>
     </record>
     <record id="igic_fptt_irpf21asale_9_5_A" model="account.fiscal.position.tax.template">
@@ -2680,15 +3106,15 @@
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf21a"/>
     </record>
     <!-- ============ -->
-        <!-- IGIC EXENTOS -->
-        <!-- ============ -->
-        <record id="igic_fp_exento" model="account.fiscal.position.template">
+    <!-- IGIC EXENTOS -->
+    <!-- ============ -->
+    <record id="igic_fp_exento" model="account.fiscal.position.template">
         <field name="name">Exento de IGIC</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="note">Las exenciones en operaciones interiores en el Impuesto General Indirecto Canario (IGIC) se encuentra regulados en el Art. 50, LEY 4/2012, del 25 de junio.</field>
     </record>
     <!--Soportado Operaciones corrientes -->
-        <record id="igic_fp_exento_0" model="account.fiscal.position.tax.template">
+    <record id="igic_fp_exento_0" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_exento"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_ex"/>
@@ -2701,6 +3127,11 @@
     <record id="igic_fp_exento_6_5" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_exento"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_p_ex"/>
+    </record>
+    <record id="igic_fp_exento_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="igic_fp_exento"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_ex"/>
     </record>
     <record id="igic_fp_exento_9_5" model="account.fiscal.position.tax.template">
@@ -2734,6 +3165,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_p_ex"/>
     </record>
+    <record id="igic_fp_exento_7_inv" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="igic_fp_exento"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_p_ex"/>
+    </record>
     <record id="igic_fp_exento_9_5_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_exento"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_9_5_inv"/>
@@ -2765,6 +3201,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_6_5"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_re_ex"/>
     </record>
+    <record id="igic_fp_exento_ventas_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="igic_fp_exento"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_r_7"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_re_ex"/>
+    </record>
     <record id="igic_fp_exento_ventas_9_5" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_exento"/>
         <field name="tax_src_id" ref="account_tax_template_igic_r_9_5"/>
@@ -2785,10 +3226,10 @@
     <!-- =========================== -->
     <record id="igic_fp_minorista" model="account.fiscal.position.template">
         <field name="name">IGIC Proveedor minorista</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     </record>
      <!--Soportado Operaciones corrientes -->
-        <record id="igic_fp_minorista_0" model="account.fiscal.position.tax.template">
+    <record id="igic_fp_minorista_0" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_minorista"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_cmino"/>
@@ -2801,6 +3242,11 @@
     <record id="igic_fp_minorista_6_5" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_minorista"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_cmino"/>
+    </record>
+    <record id="igic_fp_minorista_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="igic_fp_minorista"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_cmino"/>
     </record>
     <record id="igic_fp_minorista_9_5" model="account.fiscal.position.tax.template">
@@ -2832,6 +3278,11 @@
     <record id="igic_fp_minorista_6_5_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="igic_fp_minorista"/>
         <field name="tax_src_id" ref="account_tax_template_igic_sop_6_5_inv"/>
+        <field name="tax_dest_id" ref="account_tax_template_igic_cmino"/>
+    </record>
+    <record id="igic_fp_minorista_7_inv" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="igic_fp_minorista"/>
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_7_inv"/>
         <field name="tax_dest_id" ref="account_tax_template_igic_cmino"/>
     </record>
     <record id="igic_fp_minorista_9_5_inv" model="account.fiscal.position.tax.template">

--- a/l10n_es_igic/data/taxes_common_igic.xml
+++ b/l10n_es_igic/data/taxes_common_igic.xml
@@ -40,7 +40,19 @@
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
     </record>
-        <record id="account_tax_template_igic_r_9_5" model="account.tax.template">
+    <record id="account_tax_template_igic_r_7" model="account.tax.template">
+        <field name="sequence" eval="4"/>
+        <field name="description">S_IGIC_R7</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_4777_child"/>
+        <field name="name">IGIC 7%</field>
+        <field name="refund_account_id" ref="pgc_4777_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_r_9_5" model="account.tax.template">
         <field name="description">S_IGIC_R95</field>
         <field name="type_tax_use">sale</field>
         <field name="account_id" ref="pgc_4777_child"/>
@@ -50,7 +62,7 @@
         <field name="amount" eval="9.5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_95"/>
-        </record>
+    </record>
     <record id="account_tax_template_igic_r_13_5" model="account.tax.template">
         <field name="description">S_IGIC_R135</field>
         <field name="type_tax_use">sale</field>
@@ -81,7 +93,7 @@
         <field name="account_id" ref="pgc_4777_child"/>
         <field name="name">IGIC 0,30% (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4777_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0.30" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_03"/>
@@ -92,7 +104,7 @@
         <field name="account_id" ref="pgc_4777_child"/>
         <field name="name">IGIC 0,5% (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4777_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_05"/>
@@ -103,7 +115,7 @@
         <field name="account_id" ref="pgc_4777_child"/>
         <field name="name">IGIC 0,9% (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4777_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0.9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_09"/>
@@ -114,7 +126,7 @@
         <field name="account_id" ref="pgc_4777_child"/>
         <field name="name">IGIC 1,3% (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4777_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="1.3" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_13"/>
@@ -125,7 +137,7 @@
         <field name="account_id" ref="pgc_4777_child"/>
         <field name="name">IGIC 2% (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4777_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="2" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_200"/>
@@ -227,6 +239,38 @@
         <field name="amount_type">group</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_igic_s_ISP6_5_1'), ref('account_tax_template_igic_s_ISP6_5_2')])]"/>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
+    </record>
+    <record id="account_tax_template_igic_s_ISP7_1" model="account.tax.template">
+        <field name="description">S_IGIC_ISP7_1</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Venta con Inversión del Sujeto Pasivo (1)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_s_ISP7_2" model="account.tax.template">
+        <field name="description">S_IGIC_ISP7_2</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_4777_child"/>
+        <field name="name">IGIC 7% Venta con Inversión del Sujeto Pasivo (2)</field>
+        <field name="refund_account_id" ref="pgc_4777_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="-7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_s_ISP7" model="account.tax.template">
+        <field name="description">S_IGIC_ISP7</field>
+        <field name="type_tax_use">sale</field>
+        <field name="name">IGIC 7% Venta con Inversión del Sujeto Pasivo</field>
+        <field name="amount_type">group</field>
+        <field name="amount" eval="100" />
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_igic_s_ISP7_1'), ref('account_tax_template_igic_s_ISP7_2')])]"/>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
     </record>
     <record id="account_tax_template_igic_s_ISP95_1" model="account.tax.template">
         <field name="description">S_IGIC_ISP95_1</field>
@@ -330,7 +374,7 @@
         <field name="description">S_IGIC_EX0</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IGIC 0% (Exportaciones)</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0.00" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_0"/>
@@ -341,7 +385,7 @@
         <field name="description">S_IGIC_EXENTO</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IGIC Exento Repercutido</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_ex"/>
@@ -384,6 +428,18 @@
         <field eval="6.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
+    </record>
+    <record id="account_tax_template_igic_sop_7" model="account.tax.template">
+        <field name="sequence" eval="4"/>
+        <field name="description">P_IGIC_BC7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Soportado (Operaciones corrientes)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
     </record>
     <record id="account_tax_template_igic_sop_9_5" model="account.tax.template">
         <field name="description">P_IGIC_BC95</field>
@@ -453,8 +509,19 @@
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
     </record>
-        <record id="account_tax_template_igic_sop_9_5_inv" model="account.tax.template">
-                <field name="description">P_IGIC_BI95</field>
+    <record id="account_tax_template_igic_sop_7_inv" model="account.tax.template">
+        <field name="description">P_IGIC_BI7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Soportado (Operaciones de inversión)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_sop_9_5_inv" model="account.tax.template">
+        <field name="description">P_IGIC_BI95</field>
         <field name="type_tax_use">purchase</field>
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 9,5% Soportado (Operaciones de inversión)</field>
@@ -463,7 +530,7 @@
         <field eval="9.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_95"/>
-        </record>
+    </record>
     <record id="account_tax_template_igic_sop_13_5_inv" model="account.tax.template">
         <field name="description">P_IGIC_BI135</field>
         <field name="type_tax_use">purchase</field>
@@ -494,7 +561,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 0% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_0"/>
@@ -505,7 +572,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 3% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="3" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_3"/>
@@ -516,10 +583,21 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 6,5% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="6.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
+    </record>
+    <record id="account_tax_template_igic_sop_i_7" model="account.tax.template">
+        <field name="description">P_IGIC_IBC7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Importaciones (Operaciones corrientes)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
     </record>
     <record id="account_tax_template_igic_sop_i_9_5" model="account.tax.template">
         <field name="description">P_IGIC_IBC95</field>
@@ -527,7 +605,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 9,5% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="9.50" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_95"/>
@@ -538,7 +616,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 13,5% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="13.50" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_135"/>
@@ -549,7 +627,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 20% Importaciones (Operaciones corrientes)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="20" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_200"/>
@@ -562,7 +640,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 0% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_0"/>
@@ -573,7 +651,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 3% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="3" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_3"/>
@@ -584,18 +662,29 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 6,5% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="6.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
     </record>
-        <record id="account_tax_template_igic_sop_i_9_5_inv" model="account.tax.template">
-                <field name="description">P_IGIC_IBI95</field>
+    <record id="account_tax_template_igic_sop_i_7_inv" model="account.tax.template">
+        <field name="description">P_IGIC_IBI7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Importaciones (Operaciones de inversión)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_sop_i_9_5_inv" model="account.tax.template">
+        <field name="description">P_IGIC_IBI95</field>
         <field name="type_tax_use">purchase</field>
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 9,5% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="9.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_95"/>
@@ -606,7 +695,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 13,5% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="13.5" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_135"/>
@@ -617,7 +706,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 20% Importaciones (Operaciones de inversión)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="20" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_200"/>
@@ -719,6 +808,38 @@
         <field name="amount_type">group</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_igic_ISP6_5_1'), ref('account_tax_template_igic_ISP6_5_2')])]"/>
         <field name="tax_group_id" ref="tax_group_igic_6_5"/>
+    </record>
+    <record id="account_tax_template_igic_ISP7_1" model="account.tax.template">
+        <field name="description">P_IGIC_ISP7_1</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4727_child"/>
+        <field name="name">IGIC 7% Compra con Inversión del Sujeto Pasivo (1)</field>
+        <field name="refund_account_id" ref="pgc_4727_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_ISP7_2" model="account.tax.template">
+        <field name="description">P_IGIC_ISP7_2</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_4777_child"/>
+        <field name="name">IGIC 7% Compra con Inversión del Sujeto Pasivo (2)</field>
+        <field name="refund_account_id" ref="pgc_4777_child"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field eval="-7" name="amount"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
+    </record>
+    <record id="account_tax_template_igic_ISP7" model="account.tax.template">
+        <field name="description">P_IGIC_ISP7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 7% Compra con Inversión del Sujeto Pasivo</field>
+        <field name="amount_type">group</field>
+        <field name="amount" eval="100"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_igic_ISP7_1'), ref('account_tax_template_igic_ISP7_2')])]"/>
+        <field name="tax_group_id" ref="tax_group_igic_7"/>
     </record>
     <record id="account_tax_template_igic_ISP95_1" model="account.tax.template">
         <field name="description">P_IGIC_ISP95_1</field>
@@ -824,7 +945,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 0,30% Compras (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0.3"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_03"/>
@@ -835,7 +956,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 0,5% Compras (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0.5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_05"/>
@@ -846,7 +967,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 0,9% Compras (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0.9"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_09"/>
@@ -857,7 +978,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 1,3% Compras (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="1.3"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_13"/>
@@ -868,7 +989,7 @@
         <field name="account_id" ref="pgc_4727_child"/>
         <field name="name">IGIC 2% Compras (Recargo a la importación)</field>
         <field name="refund_account_id" ref="pgc_4727_child"/>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="2"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_re_200"/>
@@ -879,7 +1000,7 @@
         <field name="description">P_IGIC_EXENTO</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IGIC Exento Soportado</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_ex"/>
@@ -890,7 +1011,7 @@
         <field name="description">S_IGIC_MINOR</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Exento por Comercio minorista</field>
-        <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_igic_cmino"/>


### PR DESCRIPTION
Hola,

Traigo unos cambios que se hicieron en las 12.0, la inclusión de nuevo del impuesto del 7% que entra en vigor en 2020 y la eliminación del pgc específico canario por lo problemas que se comentan en el PR de las 12.0. Os lo propongo aquí para que ya se actualice el PR: https://github.com/OCA/l10n-spain/pull/1105 al hacer merge, al cual tras este commit sólo le faltaría hacer squash y corregir los autores y ya se podría mergear.

Un saludo