### PR TITLE
[11.0][IMP] l10n_es_aeat_mod303_extra_data: New BOE format for 2023

### DIFF
--- a/l10n_es_aeat_mod303_extra_data/__manifest__.py
+++ b/l10n_es_aeat_mod303_extra_data/__manifest__.py
@@ -17,5 +17,7 @@
     ],
     "data": [
         "data/2021-07/l10n_es_aeat_map_tax_line.xml",
+        "data/2023/l10n_es_aeat_map_tax_line.xml",
     ],
+    "autoinstall": True,
 }

--- a/l10n_es_aeat_mod303_extra_data/data/2023/l10n_es_aeat_map_tax_line.xml
+++ b/l10n_es_aeat_mod303_extra_data/data/2023/l10n_es_aeat_map_tax_line.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_10" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_11" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_12" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_13" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_14_sale" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0s')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_14_purchase" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_15_sale" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0s')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_15_purchase" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_16" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_18" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_25" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_26" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_28" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_29" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_32" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ia'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_33" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ia'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_36" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_37" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_40" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_41" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_isc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_sc')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ia')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_80" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0s')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_96" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_150" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_152" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva0s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_153" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
+        ]"/>
+    </record>
+    <record id="l10n_es_aeat_mod303.aeat_mod303_2023_map_line_155" model="l10n.es.aeat.map.tax.line">
+        <field name="tax_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
+        ]"/>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport from:

- https://github.com/OCA/l10n-spain/pull/2847
- https://github.com/OCA/l10n-spain/pull/2869

Depends on:

- https://github.com/factorlibre/l10n-spain/pull/48
- https://github.com/factorlibre/l10n-spain/pull/50