### PR TITLE
[11.0][FIX] l10n_es_partner: Python 3.8+ time.clock removed

### DIFF
--- a/l10n_es_partner/gen_src/gen_data_banks.py
+++ b/l10n_es_partner/gen_src/gen_data_banks.py
@@ -7,7 +7,14 @@ import codecs
 from datetime import datetime
 import os
 try:
+    import sys
+
     import xlrd
+
+    if sys.version_info >= (3, 8):
+        import time
+
+        time.clock = time.time
 except ImportError:
     xlrd = None
 


### PR DESCRIPTION
Monkeypatch time.clock para versiones de Python 3.8+