### PR TITLE
[IMP] l10n_es_aeat_sii: Implement send with quarters only for voluntary

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -764,7 +764,7 @@ class AccountInvoice(models.Model):
         partner = self.partner_id.commercial_partner_id
         company = self.company_id
         ejercicio = fields.Date.from_string(self.date).year
-        periodo = '%02d' % fields.Date.from_string(self.date).month
+        periodo = self._get_document_period()
         is_simplified_invoice = self._is_sii_simplified_invoice()
         inv_dict = {
             "IDFactura": {
@@ -860,7 +860,7 @@ class AccountInvoice(models.Model):
         reg_date = self._change_date_format(
             self._get_account_registration_date())
         ejercicio = fields.Date.from_string(self.date).year
-        periodo = '%02d' % fields.Date.from_string(self.date).month
+        periodo = self._get_document_period()
         desglose_factura, tax_amount, not_in_amount_total = (
             self._get_sii_in_taxes())
         inv_dict = {
@@ -935,6 +935,14 @@ class AccountInvoice(models.Model):
                         'CuotaRectificada': refund_tax_amount,
                     }
         return inv_dict
+
+    def _get_document_period(self):
+        month = int('%02d' % fields.Date.from_string(self.date).month)
+        if self.company_id.sii_period == "monthly":
+            period = "%02d" % month
+        else:
+            period = str(int(((month - 1) / 3) + 1)) + "T"
+        return period
 
     @api.multi
     def _get_sii_invoice_dict(self):

--- a/l10n_es_aeat_sii/models/res_company.py
+++ b/l10n_es_aeat_sii/models/res_company.py
@@ -62,6 +62,13 @@ class ResCompany(models.Model):
     delay_time = fields.Float(string="Delay time")
     sii_tax_agency_id = fields.Many2one(
         'aeat.sii.tax.agency', string='Tax Agency')
+    sii_period = fields.Selection(
+        selection=[
+            ("monthly", "Monthly"),
+            ("quarterly", "Quarterly"),
+        ],
+        default="monthly",
+    )
 
     def _get_sii_eta(self):
         if self.send_mode == 'fixed':

--- a/l10n_es_aeat_sii/views/res_company_view.xml
+++ b/l10n_es_aeat_sii/views/res_company_view.xml
@@ -18,6 +18,7 @@
                         <group name="sii_config">
                             <field name="sii_test" />
                             <field name="sii_method"/>
+                            <field name="sii_period"/>
                             <field name="sii_tax_agency_id"/>
                         </group>
                         <group name="sii_description" string="Description config">


### PR DESCRIPTION
Se añade lo implementado en https://github.com/OCA/l10n-spain/pull/3651

No se hizo backport directamente, ya que en v11 el módulo tienen distinto nombre. Comprobado vía shell que no rompe nada.