### PR TITLE
[FIX] l10n_es_aeat_mod303_extra_data: Remove ref to aeat_mod303_2024_10_map_line_96

### DIFF
--- a/l10n_es_aeat_mod303_extra_data/data/2024/l10n_es_aeat_map_tax_line.xml
+++ b/l10n_es_aeat_mod303_extra_data/data/2024/l10n_es_aeat_map_tax_line.xml
@@ -180,12 +180,6 @@
             (4, ref('l10n_es_extra_data.account_tax_template_s_iva5s'))
         ]"/>
     </record>
-    <record id="l10n_es_aeat_mod303.aeat_mod303_2024_10_map_line_96" model="l10n.es.aeat.map.tax.line">
-        <field name="tax_ids" eval="[
-            (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),
-            (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))
-        ]"/>
-    </record>
     <record id="l10n_es_aeat_mod303.aeat_mod303_2024_10_map_line_150" model="l10n.es.aeat.map.tax.line">
         <field name="tax_ids" eval="[
             (4, ref('l10n_es_extra_data.account_tax_template_s_iva0_a')),


### PR DESCRIPTION
[#e1ec72f](https://github.com/factorlibre/l10n-spain/commit/e1ec72f66b49df428b92bd5d48c3fa155bbe778a) commit deletes record `aeat_mod303_2024_10_map_line_96` from `l10n_es_aeat_mod303`. 
Here it was still referenced. It was causing:
```bash
odoo.tools.convert.ParseError: "null value in column "field_number" of relation "l10n_es_aeat_map_tax_line" violates not-null constraint
DETAIL:  Failing row contains (371, null, null, null, all, amount, both, f, f, 1, 2025-07-08 07:17:38.692055, 1, 2025-07-08 07:17:38.692055, yes).
" while parsing /opt/odoo/odoo-base/common-11.0/l10n-spain/l10n_es_aeat_mod303_extra_data/data/2024/l10n_es_aeat_map_tax_line.xml:183, near
<record id="l10n_es_aeat_mod303.aeat_mod303_2024_10_map_line_96" model="l10n.es.aeat.map.tax.line">
        <field name="tax_ids" eval="[             (4, ref('l10n_es_extra_data.account_tax_template_s_req0')),             (4, ref('l10n_es_extra_data.account_tax_template_s_req062'))         ]"/>
    </record>
```
