### PR TITLE
[FIX] l10n_es_verifactu_pos_oca: correct amounts on refund pos orders.

### DIFF
--- a/l10n_es_verifactu_pos_oca/README.rst
+++ b/l10n_es_verifactu_pos_oca/README.rst
@@ -68,7 +68,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
-
+* Almudena de La Puente <almudena.delapuente@factorlibre.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_verifactu_pos_oca/models/pos_order.py
+++ b/l10n_es_verifactu_pos_oca/models/pos_order.py
@@ -16,50 +16,6 @@ class PosOrder(models.Model):
     _name = "pos.order"
     _inherit = ["pos.order", "verifactu.mixin"]
 
-    last_verifactu_invoice_entry_id = fields.Many2one(
-        comodel_name="verifactu.invoice.entry",
-        string="Last Verifactu Invoice Entry",
-        help="Last verifactu invoice entry for this POS order.",
-        copy=False,
-        readonly=True,
-    )
-    last_verifactu_response_line_id = fields.Many2one(
-        "verifactu.invoice.entry.response.line",
-        string="Last Verifactu Response Line",
-        readonly=True,
-    )
-    verifactu_registration_key = fields.Many2one(
-        comodel_name="verifactu.registration.key",
-        compute="_compute_verifactu_registration_key",
-        store=True,
-        readonly=False,
-    )
-    verifactu_tax_key = fields.Selection(
-        compute="_compute_verifactu_tax_key",
-        store=True,
-        readonly=False,
-    )
-    verifactu_registration_key_code = fields.Char(
-        compute="_compute_verifactu_registration_key_code",
-        readonly=True,
-    )
-    verifactu_invoice_entry_ids = fields.One2many(
-        "verifactu.invoice.entry",
-        inverse_name="document_id",
-        domain=lambda doc: [("model", "=", doc._name)],
-        string="VeriFactu Invoice Entry",
-        readonly=True,
-        copy=False,
-    )
-    verifactu_response_line_ids = fields.One2many(
-        "verifactu.invoice.entry.response.line",
-        inverse_name="document_id",
-        domain=lambda doc: [("model", "=", doc._name)],
-        string="Verifactu Response Lines",
-        readonly=True,
-        copy=False,
-    )
-
     @api.depends(
         "company_id",
         "company_id.verifactu_enabled",
@@ -123,13 +79,6 @@ class PosOrder(models.Model):
                 order.verifactu_registration_key = verifactu_key_obj.search(
                     domain, limit=1
                 )
-
-    @api.depends("verifactu_registration_key")
-    def _compute_verifactu_registration_key_code(self):
-        for order in self:
-            order.verifactu_registration_key_code = (
-                order.verifactu_registration_key.code
-            )
 
     @api.model
     def _process_order(self, order, draft, existing_order):
@@ -222,12 +171,6 @@ class PosOrder(models.Model):
     def _get_verifactu_issuer(self):
         return self.company_id.partner_id._parse_aeat_vat_info()[2]
 
-    def _get_verifactu_amount_tax(self):
-        return abs(self.amount_tax)  # VeriFactu uses absolute values
-
-    def _get_verifactu_amount_total(self):
-        return abs(self.amount_total)  # VeriFactu uses absolute values
-
     def _verifactu_get_partner(self):
         """Get the partner for AEAT purposes"""
         return (
@@ -248,7 +191,7 @@ class PosOrder(models.Model):
     def _get_verifactu_qr_values(self):
         """Get the QR values for the verifactu"""
         self.ensure_one()
-        amount_total = self._get_verifactu_amount_total()
+        _taxes_dict, _amount_tax, amount_total = self._get_verifactu_taxes_and_total()
         return OrderedDict(
             [
                 ("nif", self._get_verifactu_issuer()),
@@ -416,11 +359,25 @@ class PosOrder(models.Model):
         taxes_S2 = self._get_verifactu_taxes_map(["S2"], document_date)
         taxes_N1 = self._get_verifactu_taxes_map(["N1"], document_date)
         taxes_N2 = self._get_verifactu_taxes_map(["N2"], document_date)
+        taxes_RE = self._get_verifactu_taxes_map(["RE"], document_date)
+        taxes_not_in_total = self._get_verifactu_taxes_map(
+            ["TaxNotIncludedInTotal"], document_date
+        )
+        base_not_in_total = self._get_verifactu_taxes_map(
+            ["BaseNotIncludedInTotal"], document_date
+        )
+        excluded_taxes = taxes_not_in_total + base_not_in_total
         breakdown_taxes = taxes_S1 + taxes_S2 + taxes_N1 + taxes_N2
+        not_in_amount_total = 0.0
+        not_in_taxes = 0.0
 
         # Build tax breakdown
         for tax_line in tax_lines.values():
             tax = tax_line["tax"]
+            if tax in taxes_not_in_total:
+                not_in_amount_total += tax_line["amount"]
+            elif tax in base_not_in_total:
+                not_in_amount_total += tax_line["base"]
             if tax in breakdown_taxes:
                 operation_type = self._get_verifactu_operation_type(
                     tax_line, taxes_S1, taxes_S2, taxes_N1, taxes_N2
@@ -430,13 +387,23 @@ class PosOrder(models.Model):
                     "ClaveRegimen": self.verifactu_registration_key_code,
                     "CalificacionOperacion": operation_type,
                 }
-                tax_dict.update(self._get_verifactu_tax_dict(tax_line, tax_lines))
+                if operation_type not in ("N1", "N2"):
+                    new_tax_dict = self._get_verifactu_tax_dict(tax_line, tax_lines)
+                    tax_dict.update(new_tax_dict)
+                else:
+                    tax_dict.update({"BaseImponibleOimporteNoSujeto": tax_line["base"]})
                 taxes_dict["DetalleDesglose"].append(tax_dict)
-
+            elif tax in excluded_taxes:
+                not_in_taxes += tax_line["amount"]
+            elif tax not in taxes_RE:
+                raise UserError(_("%s tax is not mapped to VERI*FACTU.", tax.name))
+        sign = -1 if self._is_refund_order() else 1
+        amount_tax = self.amount_tax - not_in_taxes * sign
+        amount_total = self.amount_total - not_in_amount_total
         return (
             taxes_dict,
-            self._get_verifactu_amount_tax(),
-            self._get_verifactu_amount_total(),
+            amount_tax,
+            amount_total,
         )
 
     def _get_verifactu_tax_dict(self, tax_line, tax_lines):

--- a/l10n_es_verifactu_pos_oca/readme/CONTRIBUTORS.rst
+++ b/l10n_es_verifactu_pos_oca/readme/CONTRIBUTORS.rst
@@ -1,2 +1,2 @@
 * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
-
+* Almudena de La Puente <almudena.delapuente@factorlibre.com>

--- a/l10n_es_verifactu_pos_oca/static/description/index.html
+++ b/l10n_es_verifactu_pos_oca/static/description/index.html
@@ -417,6 +417,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
 <ul class="simple">
 <li>Luis J. Salvatierra &lt;<a class="reference external" href="mailto:luis.salvatierra&#64;factorlibre.com">luis.salvatierra&#64;factorlibre.com</a>&gt;</li>
+<li>Almudena de La Puente &lt;<a class="reference external" href="mailto:almudena.delapuente&#64;factorlibre.com">almudena.delapuente&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
+++ b/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
@@ -405,31 +405,6 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
             rectified_invoice["NumSerieFactura"], order_1._get_document_serial_number()
         )
 
-    def test_pos_verifactu_absolute_amounts(self):
-        """Test that VeriFactu uses absolute amounts for refunds"""
-        # Create a refund order
-        orders_data = [self._create_ui_order_data(amount=-100)]
-        order_ids = self.env["pos.order"].create_from_ui(orders_data)
-        order = self.env["pos.order"].browse(order_ids[0]["id"])
-
-        # Check that amounts are absolute
-        self.assertEqual(
-            order._get_verifactu_amount_total(), 121.0, "Should use absolute amount"
-        )
-        self.assertEqual(
-            order._get_verifactu_amount_tax(), 21.0, "Should use absolute tax"
-        )
-
-        # Check invoice dict uses absolute values
-        result = order._get_verifactu_invoice_dict_out()
-        alta = result["RegistroAlta"]
-        self.assertEqual(
-            float(alta["ImporteTotal"]), 121.0, "Invoice dict should use absolute total"
-        )
-        self.assertEqual(
-            float(alta["CuotaTotal"]), 21.0, "Invoice dict should use absolute tax"
-        )
-
     def test_pos_verifactu_l10n_es_pos_integration(self):
         """Test integration with l10n_es_pos simplified invoices"""
         # Test that simplified invoice numbers are used correctly
@@ -464,10 +439,9 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
             "TipoFactura=R5", hash_string, "Should use R5 document type in hash"
         )
 
-        # Should use absolute amounts
-        self.assertIn("CuotaTotal=21", hash_string, "Should use absolute tax amount")
+        self.assertIn("CuotaTotal=-21", hash_string, "Should be negative tax amount")
         self.assertIn(
-            "ImporteTotal=121", hash_string, "Should use absolute total amount"
+            "ImporteTotal=-121", hash_string, "Should be negative total amount"
         )
 
     def test_pos_verifactu_mixed_order_types(self):
@@ -499,10 +473,10 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
         )
 
         # Verify amount handling
-        self.assertEqual(order_sale._get_verifactu_amount_total(), 121.0)
-        self.assertEqual(
-            order_refund._get_verifactu_amount_total(), 60.5
-        )  # Absolute value
+        _tx_dict, _am_tax, amount_total = order_sale._get_verifactu_taxes_and_total()
+        self.assertEqual(amount_total, 121.0)
+        _tx_dict, _am_tax, amount_total = order_refund._get_verifactu_taxes_and_total()
+        self.assertEqual(amount_total, -60.5)
 
     def test_pos_verifactu_start_date(self):
         """Test POS order verifactu enablement with start date"""


### PR DESCRIPTION
[FIX] l10n_es_verifactu_pos_oca: correct amounts on refund pos orders
[IMP] l10n_es_verifactu_pos_oca: clean unnecessary fields already defined on verifactu.mixin