### PR TITLE
[11.0][FIX] l10n_es_vat_prorate: avoid negative move line on negative base …

### DIFF
--- a/l10n_es_vat_prorate/models/account_invoice.py
+++ b/l10n_es_vat_prorate/models/account_invoice.py
@@ -133,23 +133,30 @@ class AccountInvoice(models.Model):
                             amount += taxes.get("amount", 0)
                         new_line_vals = line_values.copy()
 
-                        proportion = (
+                        proportion_debit = (
                             amount / line_values["debit"]
                             if line_values["debit"] else 0
                         )
-                        new_line_vals["debit"] = float_round(
-                            remaining_debit * proportion,
-                            precision_rounding=prec,
-                        )
-
-                        proportion = (
+                        proportion_credit = (
                             amount / line_values["credit"]
                             if line_values["credit"] else 0
                         )
-                        new_line_vals["credit"] = float_round(
-                            remaining_credit * proportion,
+                        nd_debit = float_round(
+                            remaining_debit * proportion_debit,
                             precision_rounding=prec,
                         )
+                        nd_credit = float_round(
+                            remaining_credit * proportion_credit,
+                            precision_rounding=prec,
+                        )
+                        # A negative base line yields a negative per-account
+                        # share of the non-deductible tax. Keep debit and credit
+                        # non-negative by moving a negative amount to the
+                        # opposite column (account_move_line credit_debit2
+                        # check: credit + debit >= 0).
+                        net = nd_debit - nd_credit
+                        new_line_vals["debit"] = net if net > 0 else 0.0
+                        new_line_vals["credit"] = -net if net < 0 else 0.0
 
                         new_line_vals.update(
                             {

--- a/l10n_es_vat_prorate/tests/test_vat_prorate.py
+++ b/l10n_es_vat_prorate/tests/test_vat_prorate.py
@@ -160,3 +160,60 @@ class TestVatProrate(common.SavepointCase):
         self.assertEqual(
             2, len(invoice.move_id.line_ids.filtered(lambda r: r.tax_line_id))
         )
+
+    def test_prorate_negative_base_line(self):
+        """A negative base line whose account only holds that negative line
+        produces a negative non-deductible share. It must land on the opposite
+        column instead of a negative debit/credit, so the move can be posted
+        (account_move_line credit_debit2 check: credit + debit >= 0)."""
+        self.tax_purchase_a.with_vat_prorate = True
+        invoice = self.env["account.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "journal_id": self.journal_c1.id,
+                "account_id": self.account_type.id,
+                "type": "in_invoice",
+                "company_id": self.company.id,
+            }
+        )
+        # Positive line on one account.
+        self.env["account.invoice.line"].create(
+            {
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": 90.0,
+                "invoice_id": invoice.id,
+                "name": "service",
+                "account_id": self.account.id,
+                "invoice_line_tax_ids": [(6, 0, [self.tax_purchase_a.id])],
+            }
+        )
+        # Negative correction line on a different account: its only movement
+        # for this tax is negative, so its non-deductible share is negative.
+        self.env["account.invoice.line"].create(
+            {
+                "product_id": self.product.id,
+                "quantity": -1.0,
+                "price_unit": 30.0,
+                "invoice_id": invoice.id,
+                "name": "correction",
+                "account_id": self.account2.id,
+                "invoice_line_tax_ids": [(6, 0, [self.tax_purchase_a.id])],
+            }
+        )
+        invoice._onchange_invoice_line_ids()
+        # Must not raise a CheckViolation on the negative prorate line.
+        invoice.action_invoice_open()
+        self.assertEqual("open", invoice.state)
+        # No move line may carry a negative debit or credit.
+        for move_line in invoice.move_id.line_ids:
+            self.assertGreaterEqual(move_line.debit, 0.0)
+            self.assertGreaterEqual(move_line.credit, 0.0)
+        # The negative line's non-deductible share is booked on the credit side.
+        negative_prorate = invoice.move_id.line_ids.filtered(
+            lambda r: r.vat_prorate and r.account_id == self.account2
+        )
+        self.assertTrue(negative_prorate)
+        self.assertTrue(
+            all(ml.credit > 0 and not ml.debit for ml in negative_prorate)
+        )


### PR DESCRIPTION
…with prorate

When a base line has a negative amount and its account only holds negative movements for a prorated tax, the non-deductible share was booked as a negative debit, violating the account_move_line credit_debit2 SQL check (credit + debit >= 0) and blocking the invoice validation.

Book a negative non-deductible share on the opposite column instead of as a negative debit/credit. Add a regression test covering a mixed invoice with a negative base line whose account only holds that negative line.